### PR TITLE
Fix EPUBs not rendering on iOS (upgrade pandoc 2.9 → 3.9)

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -22,11 +22,11 @@ jobs:
         run: |
           python apracticalguidetoevil.py
 
-      - uses: docker://pandoc/core:2.9
+      - uses: docker://pandoc/core:3.9
         with:
           args: -o "Pale Lights.epub" "Pale Lights.md"
 
-      - uses: docker://pandoc/core:2.9
+      - uses: docker://pandoc/core:3.9
         with:
           args: -o "A Practical Guide to Evil.epub" "A Practical Guide to Evil.md"
 


### PR DESCRIPTION
## Problem

The generated EPUBs fail to open / render on **iOS Apple Books**, while they work fine in Calibre, Kindle, and Android readers.

## Root cause

The CI workflow builds the books with `docker://pandoc/core:2.9`. Pandoc 2.9's EPUB writer emits a **duplicate `data-number` attribute** on every chapter `<section>`:

```xml
<section id="chapter-1" class="level1 section" data-number="1" data-number="1">
```

A repeated attribute is an XML well-formedness violation. iOS Apple Books uses a strict XML parser and refuses to render the content documents; other readers use lenient HTML parsers and silently tolerate it — which is why it only broke on iOS. `xmllint` reports it on every chapter file:

```
parser error : Attribute data-number redefined
```

## Fix

- Bump both build steps in `.github/workflows/update.yml` from `pandoc/core:2.9` to `pandoc/core:3.9`, which emits valid XHTML.
- Regenerate the committed `A Practical Guide to Evil.epub` with pandoc 3.9 so readers get the fix immediately. Verified with `xmllint`: every content document is now well-formed.

A follow-up PR migrates the Pale Lights scraper to Royal Road and ships its regenerated (also iOS-valid) EPUB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)