### PR TITLE
Run rescrape daily + make EPUB builds reproducible

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -2,7 +2,7 @@ name: Rescrape
 
 on:
   schedule:
-    - cron: '0 8 * * SAT'
+    - cron: '0 8 * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -22,13 +22,21 @@ jobs:
         run: |
           python apracticalguidetoevil.py
 
+      # Pin the build timestamp (SOURCE_DATE_EPOCH) and the dc:identifier so
+      # that identical Markdown produces a byte-identical EPUB. Otherwise pandoc
+      # stamps the current time and a random UUID into every build, so the
+      # committed EPUBs churn on every run even when the source hasn't changed.
       - uses: docker://pandoc/core:3.9
+        env:
+          SOURCE_DATE_EPOCH: '1735689600'
         with:
-          args: -o "Pale Lights.epub" "Pale Lights.md"
+          args: --metadata identifier=https://www.royalroad.com/fiction/65058/pale-lights -o "Pale Lights.epub" "Pale Lights.md"
 
       - uses: docker://pandoc/core:3.9
+        env:
+          SOURCE_DATE_EPOCH: '1735689600'
         with:
-          args: -o "A Practical Guide to Evil.epub" "A Practical Guide to Evil.md"
+          args: --metadata identifier=https://practicalguidetoevil.wordpress.com -o "A Practical Guide to Evil.epub" "A Practical Guide to Evil.md"
 
       - name: Commit & Push Changes
         run: |


### PR DESCRIPTION
Two related workflow changes, kept together since the second one makes the first safe to do.

## 1. Run the scrape daily instead of weekly

```diff
-    - cron: '0 8 * * SAT'
+    - cron: '0 8 * * *'
```

New chapters land within ~24h of posting instead of up to a week. `workflow_dispatch` is unchanged.

## 2. Make EPUB builds reproducible

pandoc stamps the current build time (`dcterms:modified`) **and a freshly-generated random UUID** (`dc:identifier`) into every EPUB. So each run produced a byte-different EPUB even when the source Markdown hadn't changed, and `git commit -am` committed that churn. That's why:

- the committed EPUBs drift ahead of their `.md` files (e.g. PGTE's `.epub` showing a newer commit than its `.md`), and
- going daily would otherwise create a no-op "Update books" commit *every single day*.

Fix — pin both sources of nondeterminism on the pandoc steps:

- `SOURCE_DATE_EPOCH: '1735689600'` (fixed timestamp)
- `--metadata identifier=<stable per-book URL>` (fixed `dc:identifier`)

Verified locally with pandoc 3.9 that identical Markdown now produces a **byte-identical** EPUB across builds. After this, the EPUBs only change when their `.md` actually changes.

**One-time transition:** the first run after merge will rebuild both EPUBs once (new fixed identifier/date) and commit them; every run after that is a true no-op unless content changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)