### PR TITLE
Don't fail scheduled runs when there's nothing to commit

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -42,5 +42,12 @@ jobs:
         run: |
           git config user.name github-actions[bot]
           git config user.email github-actions[bot]@users.noreply.github.com
-          git commit -am "[Automated]: Update books"
-          git push
+          # Only commit/push when something actually changed. Now that the EPUB
+          # builds are reproducible, a run with no new chapters produces an empty
+          # diff, and an unconditional `git commit` would exit non-zero and fail.
+          if [ -n "$(git status --porcelain)" ]; then
+            git commit -am "[Automated]: Update books"
+            git push
+          else
+            echo "No changes to commit"
+          fi


### PR DESCRIPTION
## Problem

Scheduled runs now fail on days with no new chapters:

```
nothing to commit, working tree clean
Error: Process completed with exit code 1.
```

This is a side effect of the reproducible-EPUB change (#9): EPUBs are now byte-identical when the source Markdown is unchanged, so a run with no new content produces a completely empty diff. The unconditional `git commit -am` then exits non-zero and fails the job. (Previously, pandoc's random per-build UUID guaranteed an EPUB change every run, so there was always something to commit — masking this.)

## Fix

Only commit and push when `git status --porcelain` reports changes; otherwise log "No changes to commit" and exit cleanly. No-new-chapter runs now go green instead of red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)